### PR TITLE
Change method from MSShapeGroup to shapeWithRect

### DIFF
--- a/Bootstrap grid.sketchplugin/Contents/Sketch/build-grid.js
+++ b/Bootstrap grid.sketchplugin/Contents/Sketch/build-grid.js
@@ -19,8 +19,7 @@ var BuildGrid = {
      * Creating shape.
      */
     createShape (x, y, width, height, index, overlayColor, overlayOpacity) {
-        var shape = MSRectangleShape.alloc().initWithFrame(NSMakeRect(x, y, width, height));
-        var shapeGroup = MSShapeGroup.shapeWithPath(shape);
+        var shapeGroup = MSShapeGroup.shapeWithRect(NSMakeRect(x, y, width, height));
 
         shapeGroup.setName("Col " + index);
         shapeGroup.style().contextSettings().setOpacity(overlayOpacity/100);

--- a/Bootstrap grid.sketchplugin/Contents/Sketch/manifest.json
+++ b/Bootstrap grid.sketchplugin/Contents/Sketch/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Bootstrap grid",
     "identifier": "bootstrap.grid",
-    "version": "1.0",
+    "version": "1.1",
     "description": "Set bootstrap grid",
     "author": "Kirenkov Vitaliy",
     "email": "kirenkov.vitaliy@gmail.com",
@@ -38,7 +38,7 @@
         "name": "Idea: Anastasia Popova",
         "identifier": "aboutIdea"
     }],
-    
+
     "menu": {
         "items": [
             "openOptionsWindow",


### PR DESCRIPTION
Because BootstrapGrid didn't work with Sketch version 52. I changed the method shapeWithPath from MSShapeGroup to shapeWithRect to show the grid again.